### PR TITLE
Geth toml

### DIFF
--- a/default.env
+++ b/default.env
@@ -1,4 +1,4 @@
-COMPOSE_FILE=replica.yml:replica-shared.yml
+COMPOSE_FILE=replica.yml:replica-shared.yml:replica-toml.yml
 ETH_NETWORK=kovan
 DATA_TRANSPORT_LAYER__L1_RPC_ENDPOINT=WONT_WORK_UNLESS_YOU_PROVIDE_A_VALID_ETHEREUM_L1_ENDPOINT
 DATA_TRANSPORT_LAYER__L2_RPC_ENDPOINT=https://kovan.optimism.io

--- a/kustomize/replica/bases/configmaps/l2geth-replica-start.sh
+++ b/kustomize/replica/bases/configmaps/l2geth-replica-start.sh
@@ -11,9 +11,11 @@ if [[ -z $BLOCK_SIGNER_ADDRESS ]]; then
 fi
 
 exec geth \
+  --vmodule=eth/*=5,miner=4,rpc=5,rollup=4,consensus/clique=1 \
   --datadir=$DATADIR \
   --password=$DATADIR/password \
   --allow-insecure-unlock \
   --unlock=$BLOCK_SIGNER_ADDRESS \
   --mine \
-  --miner.etherbase=$BLOCK_SIGNER_ADDRESS
+  --miner.etherbase=$BLOCK_SIGNER_ADDRESS \
+  $@

--- a/kustomize/replica/bases/configmaps/l2geth.toml
+++ b/kustomize/replica/bases/configmaps/l2geth.toml
@@ -1,0 +1,5 @@
+# l2geth configs go here
+[Node.HTTPTimeouts]
+ReadTimeout = 120000000000
+WriteTimeout = 120000000000
+IdleTimeout = 120000000000

--- a/replica-toml.yml
+++ b/replica-toml.yml
@@ -1,0 +1,8 @@
+---
+version: "3.4"
+services:
+  l2geth-replica:
+    entrypoint:
+      - /bin/sh
+      - -c
+      - "/scripts/$GETH_INIT_SCRIPT && /scripts/l2geth-replica-start.sh --config /scripts/l2geth.toml"


### PR DESCRIPTION
Added a docker-compose that includes a toml geth configuration.

To use the configuration file, add the `replica-toml.yaml` to the included docker-compose file list.

```
COMPOSE_FILE=replica.yml:replica-shared.yml:replica-toml.yaml
```
